### PR TITLE
Fix syntax error in JavaScript example snippet

### DIFF
--- a/annotorious/index.html
+++ b/annotorious/index.html
@@ -81,9 +81,9 @@
 </span><span style="color:#586e75"></span>anno.loadAnnotations(<span style="color:#2aa198">&#39;annotations.json&#39;</span>);
 
 <span style="color:#586e75">// Attach listeners to handle annotation events
-</span><span style="color:#586e75"></span>anno.on(<span style="color:#2aa198">&#39;createAnnotation&#39;</span>, <span style="color:#268bd2">function</span>(annotation)) {
+</span><span style="color:#586e75"></span>anno.on(<span style="color:#2aa198">&#39;createAnnotation&#39;</span>, <span style="color:#268bd2">function</span>(annotation) {
   console.log(<span style="color:#2aa198">&#39;Created!&#39;</span>);
-};
+)};
 </code></pre></div>
       </div>
 


### PR DESCRIPTION
The syntax of the current snippet results in the DevTools console error:

```
SyntaxError: Unexpected token
```

This pull request resolves that issue.