### PR TITLE
Add `--env-file` flag to server data population commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ pnpm-debug.log*
 .netlify/state.json
 
 .claude
+.idea

--- a/src/content/docs/guides/local-development.mdx
+++ b/src/content/docs/guides/local-development.mdx
@@ -172,8 +172,8 @@ There may be some additional requirements depending on how you intend to use you
    Run the following commands to populate the databse with default groups, roles, users, etc.
 
    ```bash
-   node create-default-groups.js -f config.json
-   node create-test-users.js -f config.json
+   node --env-file=.env create-default-groups.js -f config.json
+   node --env-file=.env create-test-users.js -f config.json
    ```
 
    :::note[Custom configuration]


### PR DESCRIPTION
# Summary

This PR adds the `--env-file` flag to the two commands in the "Populate database with roles and groups" section, which previously failed to run in some environments because the `.env` was not automatically being inserted into `process.env`.